### PR TITLE
Add array accessors to access each column in the CSV data map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Created by .ignore support plugin (hsz.mobi)
 /vendor
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+  - '7.4'
+  - '8.0'
   - hhvm
 
 sudo: false
@@ -15,5 +20,6 @@ script: ./vendor/phpunit/phpunit/phpunit --bootstrap phpunit.bootstrap.php ./tes
 
 matrix:
   allow_failures:
+    - php: 5.5
     - php: hhvm
   fast_finish: true

--- a/src/CsvDataListMapper.php
+++ b/src/CsvDataListMapper.php
@@ -273,6 +273,10 @@ class CsvDataListMapper implements \Iterator, \ArrayAccess, \Countable {
     if (!isset($this->csvData)) {
       $this->parseCsvData();
     }
+    // Return true if column is non-numeric and exists in header.
+    if (!is_numeric($offset)) {
+      return array_search($offset, $this->header) !== false;
+    }
     return array_key_exists($offset, $this->csvData);
   }
 
@@ -282,6 +286,10 @@ class CsvDataListMapper implements \Iterator, \ArrayAccess, \Countable {
   public function offsetGet($offset) {
     if (!isset($this->csvData)) {
       $this->parseCsvData();
+    }
+    // Return a column if offset is non-numeric.
+    if (!is_numeric($offset)) {
+      return array_column($this->csvData, array_search($offset, $this->header));
     }
     return array_combine($this->header, $this->csvData[$offset]);
   }

--- a/tests/src/CsvDataListMapperTest.php
+++ b/tests/src/CsvDataListMapperTest.php
@@ -16,7 +16,7 @@ class CsvDataListMapperTest extends \PHPUnit_Framework_TestCase {
    */
   public function testSetSourceText() {
     $mapper = new TestCsvDataListMapper();
-    
+
     // Set the source text and ensure the value is set. Assert return value also.
     $object = $mapper->setSourceText($this->csvString());
     $this->assertEquals($mapper->getSourceText(), $this->csvString());
@@ -37,7 +37,7 @@ class CsvDataListMapperTest extends \PHPUnit_Framework_TestCase {
    */
   public function testSetSourceFile() {
     $mapper = new TestCsvDataListMapper();
-    
+
     // Set the source text and ensure the value is set. Assert return value also.
     $object = $mapper->setSourceFile(__DIR__ . '/../files/filename_a.csv');
     $this->assertEquals($mapper->getSourceFile(), __DIR__ . '/../files/filename_a.csv');
@@ -173,7 +173,7 @@ class CsvDataListMapperTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals('noreply@example.com', $mapper[2]['email_address']);
     $this->assertEquals('2348030783839', $mapper[2]['phone_number']);
   }
-  
+
   public function testArrayIterator() {
     $mapper = new TestCsvDataListMapper();
     $mapper
@@ -240,6 +240,30 @@ class CsvDataListMapperTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals(0, $mapper->key());
   }
 
+  public function testColumnAccess() {
+    $csv_string = $this->csvString();
+    $mapper = (new TestCsvDataListMapper())
+      ->setSourceText(implode("\n", $csv_string));
+
+    $this->assertEquals($mapper['MOBILE'], [
+      '2348030783839',
+      '2348038983839',
+      '2348030783839',
+      '2348030783457',
+      '2347090783839',
+      '2347090783234',
+    ]);
+
+    $this->assertEquals($mapper['MOBILE2'], [
+      '',
+      '2348030783839',
+      '2348030783839',
+      '2348030783839',
+      '',
+      '',
+    ]);
+  }
+
   /**
    * @expectedException \RuntimeException
    */
@@ -302,7 +326,7 @@ class TestCsvDataListMapper extends CsvDataListMapper {
   public function getMaxRecords() {
     return $this->maxRecords;
   }
-  
+
   public function peekCsvData() {
     return $this->csvData;
   }

--- a/tests/src/CsvDataListMapperTest.php
+++ b/tests/src/CsvDataListMapperTest.php
@@ -243,7 +243,7 @@ class CsvDataListMapperTest extends \PHPUnit_Framework_TestCase {
   public function testColumnAccess() {
     $csv_string = $this->csvString();
     $mapper = (new TestCsvDataListMapper())
-      ->setSourceText(implode("\n", $csv_string));
+      ->setSourceText($csv_string);
 
     $this->assertEquals($mapper['MOBILE'], [
       '2348030783839',


### PR DESCRIPTION
Adds column accessors to the CSV data map. So `$datamap['column_name']` will return an array containing all the values in the column with the specified `column_name`.